### PR TITLE
Update bindgen to 0.69

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,14 @@
+{ nixpkgs ? import <nixpkgs> {} }:
+
+nixpkgs.mkShell {
+  buildInputs = [
+    nixpkgs.pkg-config
+    nixpkgs.clang
+    nixpkgs.libclang
+    nixpkgs.libvncserver
+    nixpkgs.libvncserver.dev
+  ];
+
+  LIBCLANG_PATH = "${nixpkgs.libclang.lib}/lib";
+  LIBVNCSERVER_HEADER_FILE = "${nixpkgs.libvncserver.dev}/include/rfb/rfb.h";
+}

--- a/examples/sample/main.rs
+++ b/examples/sample/main.rs
@@ -4,8 +4,7 @@ fn main() {
     println!("Hello, world!");
 
     let server = rfb_get_screen(400, 300, 8, 3, 4);
-    rfb_framebuffer_malloc(server, 400*300*4);
+    rfb_framebuffer_malloc(server, 400 * 300 * 4);
     rfb_init_server(server);
     rfb_run_event_loop(server, -1, 0);
 }
-

--- a/examples/sample16/main.rs
+++ b/examples/sample16/main.rs
@@ -2,9 +2,9 @@ use vncserver::*;
 
 fn main() {
     let server = rfb_get_screen(400, 300, 5, 3, 2);
-    rfb_framebuffer_malloc(server, 400*300*2);
+    rfb_framebuffer_malloc(server, 400 * 300 * 2);
 
-	let mut j = 0;
+    let mut j = 0;
     while j < 100 {
         for i in 0..400 {
             rfb_framebuffer_set_rgb16(server, i, j, 0xF800);
@@ -30,4 +30,3 @@ fn main() {
     rfb_framebuffer_free(server);
     rfb_screen_cleanup(server);
 }
-

--- a/vncserver/Cargo.toml
+++ b/vncserver/Cargo.toml
@@ -19,6 +19,6 @@ name = "vncserver"
 [dependencies]
 
 [build-dependencies]
-bindgen = "0.58"
+bindgen = "0.69"
 pkg-config = "0.3"
 cc = "1.0"

--- a/vncserver/build.rs
+++ b/vncserver/build.rs
@@ -14,12 +14,16 @@ fn bindgen_vncserver() {
     println!("cargo:rustc-link-search={}", lib_path.display());
     println!("cargo:rustc-link-lib=dylib=vncserver");
 
-    let header = format!(
-        "{}/rfb/rfb.h",
-        libvncserver.include_paths[0].to_str().unwrap(),
-    );
+    let header_file = match env::var("LIBVNCSERVER_HEADER_FILE") {
+        Ok(header_file) => header_file,
+        Err(_) => format!(
+            "{}/rfb/rfb.h",
+            libvncserver.include_paths[0].to_str().unwrap(),
+        ),
+    };
+
     let bindings = bindgen::Builder::default()
-        .header(header)
+        .header(header_file)
         .generate()
         .expect("unable to generate rfb bindings");
 

--- a/vncserver/build.rs
+++ b/vncserver/build.rs
@@ -6,22 +6,26 @@ use std::env;
 use std::path::PathBuf;
 
 fn bindgen_vncserver() {
-    let libvncserver= pkg_config::probe_library("libvncserver").unwrap();
+    let libvncserver = pkg_config::probe_library("libvncserver").unwrap();
 
-    let link_paths = format!("{}", libvncserver.link_paths[0].to_str().unwrap());
-    let lib_path = PathBuf::from(env::current_dir().unwrap().join(link_paths));
+    let link_paths = libvncserver.link_paths[0].to_str().unwrap();
+    let lib_path = env::current_dir().unwrap().join(link_paths);
 
     println!("cargo:rustc-link-search={}", lib_path.display());
     println!("cargo:rustc-link-lib=dylib=vncserver");
 
-    let header = format!("{}/{}", libvncserver.include_paths[0].to_str().unwrap(), "rfb/rfb.h");
+    let header = format!(
+        "{}/rfb/rfb.h",
+        libvncserver.include_paths[0].to_str().unwrap(),
+    );
     let bindings = bindgen::Builder::default()
         .header(header)
         .generate()
         .expect("unable to generate rfb bindings");
 
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-    bindings.write_to_file(out_path.join("rfb.rs"))
+    bindings
+        .write_to_file(out_path.join("rfb.rs"))
         .expect("couldn't write bindings!");
 }
 

--- a/vncserver/src/lib.rs
+++ b/vncserver/src/lib.rs
@@ -6,12 +6,11 @@
 //!
 //! ```no_run
 //! use vncserver::*;
-//! fn main() {
-//!     let server = rfb_get_screen(400, 300, 8, 3, 4);
-//!     rfb_framebuffer_malloc(server, 400*300*4);
-//!     rfb_init_server(server);
-//!     rfb_run_event_loop(server, -1, 0);
-//! }
+//!
+//! let server = rfb_get_screen(400, 300, 8, 3, 4);
+//! rfb_framebuffer_malloc(server, 400 * 300 * 4);
+//! rfb_init_server(server);
+//! rfb_run_event_loop(server, -1, 0);
 //! ```
 
 mod rfb;
@@ -31,7 +30,7 @@ pub const RFB_TRUE: i8 = 1;
 ///     depth: ::std::os::raw::c_int,
 ///     bitsPerPixel: ::std::os::raw::c_int,
 ///     sizeInBytes: ::std::os::raw::c_int,
-///     ...
+///     // ...
 /// }
 /// ```
 pub type RfbScreenInfoPtr = rfb::rfbScreenInfoPtr;
@@ -40,9 +39,20 @@ pub type RfbBool = rfb::rfbBool;
 pub type RfbKeySym = rfb::rfbKeySym;
 pub type RfbClientRec = rfb::rfbClientRec;
 
-
-pub fn rfb_get_screen(width: i32, height: i32, bits_per_sample: i32, samples_per_pixel: i32, bytes_per_pixel: i32) -> RfbScreenInfoPtr {
-    rfb::rfb_get_screen(width, height, bits_per_sample, samples_per_pixel, bytes_per_pixel)
+pub fn rfb_get_screen(
+    width: i32,
+    height: i32,
+    bits_per_sample: i32,
+    samples_per_pixel: i32,
+    bytes_per_pixel: i32,
+) -> RfbScreenInfoPtr {
+    rfb::rfb_get_screen(
+        width,
+        height,
+        bits_per_sample,
+        samples_per_pixel,
+        bytes_per_pixel,
+    )
 }
 
 pub fn rfb_screen_cleanup(ptr: RfbScreenInfoPtr) {

--- a/vncserver/src/rfb/mod.rs
+++ b/vncserver/src/rfb/mod.rs
@@ -17,7 +17,7 @@ pub fn rfb_get_screen(
     bytes_per_pixel: i32,
 ) -> rfbScreenInfoPtr {
     let mut arg_len = 0;
-    let mut arg_ptr: *mut i8 = std::ptr::null_mut();
+    let mut arg_ptr: *mut ::std::os::raw::c_char = std::ptr::null_mut();
 
     unsafe {
         rfbGetScreen(
@@ -40,7 +40,8 @@ pub fn rfb_screen_cleanup(ptr: rfbScreenInfoPtr) {
 
 pub fn rfb_framebuffer_malloc(ptr: rfbScreenInfoPtr, fb_size: u64) {
     unsafe {
-        (*ptr).frameBuffer = malloc(fb_size as ::std::os::raw::c_ulong) as *mut i8;
+        (*ptr).frameBuffer =
+            malloc(fb_size as ::std::os::raw::c_ulong) as *mut ::std::os::raw::c_char;
     }
 }
 

--- a/vncserver/src/rfb/mod.rs
+++ b/vncserver/src/rfb/mod.rs
@@ -3,20 +3,32 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
+#![allow(clippy::upper_case_acronyms)]
 
-use std;
 use core::slice;
 
 include!(concat!(std::env!("OUT_DIR"), "/rfb.rs"));
 
-
-pub fn rfb_get_screen(width: i32, height: i32, bits_per_sample: i32, samples_per_pixel: i32, bytes_per_pixel: i32) -> rfbScreenInfoPtr {
-    let mut arg_len = 0 as i32;
+pub fn rfb_get_screen(
+    width: i32,
+    height: i32,
+    bits_per_sample: i32,
+    samples_per_pixel: i32,
+    bytes_per_pixel: i32,
+) -> rfbScreenInfoPtr {
+    let mut arg_len = 0;
     let mut arg_ptr: *mut i8 = std::ptr::null_mut();
 
     unsafe {
-        let server = rfbGetScreen(&mut arg_len, &mut arg_ptr, width, height, bits_per_sample, samples_per_pixel, bytes_per_pixel);
-        server
+        rfbGetScreen(
+            &mut arg_len,
+            &mut arg_ptr,
+            width,
+            height,
+            bits_per_sample,
+            samples_per_pixel,
+            bytes_per_pixel,
+        )
     }
 }
 
@@ -39,21 +51,19 @@ pub fn rfb_framebuffer_free(ptr: rfbScreenInfoPtr) {
 }
 
 pub fn rfb_framebuffer_set_rgb16(ptr: rfbScreenInfoPtr, x: i32, y: i32, rgb16: u16) {
-	unsafe {
+    unsafe {
         let addr = (*ptr).frameBuffer as *mut u16;
         let fb_size = (*ptr).height * (*ptr).width * (*ptr).bitsPerPixel / 2;
         let slice: &mut [u16] = slice::from_raw_parts_mut(addr, fb_size as usize);
-        let pos = (*ptr).width*y + x;
+        let pos = (*ptr).width * y + x;
         if pos < fb_size {
             slice[pos as usize] = rgb16;
         }
-	}
+    }
 }
 
 pub fn rfb_process_events(ptr: rfbScreenInfoPtr, usec: i64) -> rfbBool {
-    unsafe {
-        rfbProcessEvents(ptr, usec as ::std::os::raw::c_long)
-    }
+    unsafe { rfbProcessEvents(ptr, usec as ::std::os::raw::c_long) }
 }
 
 pub fn rfb_kbd_add_event(ptr: rfbScreenInfoPtr, cb: rfbKbdAddEventProcPtr) {
@@ -63,19 +73,19 @@ pub fn rfb_kbd_add_event(ptr: rfbScreenInfoPtr, cb: rfbKbdAddEventProcPtr) {
 }
 
 pub fn rfb_mark_rect_as_modified(ptr: rfbScreenInfoPtr, x1: i32, y1: i32, x2: i32, y2: i32) {
-	unsafe {
-        rfbMarkRectAsModified(ptr,
+    unsafe {
+        rfbMarkRectAsModified(
+            ptr,
             x1 as ::std::os::raw::c_int,
             y1 as ::std::os::raw::c_int,
             x2 as ::std::os::raw::c_int,
-            y2 as ::std::os::raw::c_int);
-	}
+            y2 as ::std::os::raw::c_int,
+        );
+    }
 }
 
 pub fn rfb_is_active(ptr: rfbScreenInfoPtr) -> rfbBool {
-    unsafe {
-        rfbIsActive(ptr)
-    }
+    unsafe { rfbIsActive(ptr) }
 }
 
 pub fn rfb_init_server(ptr: rfbScreenInfoPtr) {


### PR DESCRIPTION
We need to pull in at least bindgen `0.62.0` to pull in https://github.com/rust-lang/rust-bindgen/pull/2319, so that we can run on clang 16.

This PR also fixes the tests and clippy warnings.